### PR TITLE
feat: allow extra attributes that are transparently passed through

### DIFF
--- a/modules/request.nix
+++ b/modules/request.nix
@@ -23,6 +23,8 @@ let
     });
 in
 {
+  freeformType = types.anything;
+
   options = {
     configData = mkOption {
       type = types.anything;


### PR DESCRIPTION
- we might not know yet the downstream contracts that we might want
  to satisfy in order to hand down package dependencies of a particular
  nixago pepple (keeping the domain's integrity).
- therefore, make the request module a freefrom module that can take
  untyped additional arguments of type anything

I tested in a downstream repo that the arguments are being passed along
as expected in a repl:

```
nix-repl> tf = treefmt "x86_64-linux"

nix-repl> tf.
tf.commands    tf.configData  tf.format      tf.output      tf.packages
nix-repl> tf.packages
[ «derivation /nix/store/qgag2xc1s01jvr3x43r91q1025lv2cg8-alejandra-1.4.0.drv» «derivation /nix/store/v9ry51pyilwdkclx3gqq7vymn685z3hg-prettier-2.7.0.drv» «derivation /nix/store/k92vnq4jz3cigsrmn6z1h5b41rpylplm-prettier-plugin-toml-0.3.1.drv» «derivation /nix/store/kmbx2xn033vcr4iaica1kg3l62n7par9-shfmt-3.5.1.drv» «derivation /nix/store/irj6ps94b4icsjihck42617w15ncygf9-treefmt-0.4.1.drv» ]
```

closes: #29
