### PR TITLE
fix: the quickstart guide

### DIFF
--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -6,8 +6,8 @@ Add Nixago as an input to your `flake.nix`:
 {
   inputs = {
     # ...
-    nixpkgs.url = "github:nixos/nixpkgs";
-    nixago.url = "github:jmgilman/nixago";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixago.url = "github:nix-community/nixago";
     nixago.inputs.nixpkgs.follows = "nixpkgs";
     # ...
   };


### PR DESCRIPTION
- nixpkgs-unstable already produces cache hits from `cache.nixos.org`
- that sets off the benefit of latest `nixpkgs`