### PR TITLE
fix: 1000 nixpkgs; compat with numtide/nixpkgs-unfree

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,7 @@
           lib = (import ./lib { inherit pkgs lib engines; });
 
           # Setup pkgs
-          pkgs = import nixpkgs {
-            inherit system;
-          };
+          pkgs = nixpkgs.legacyPackages.${system};
 
           # Import test runner
           runTests = import ./tests/common.nix { inherit pkgs engines; };


### PR DESCRIPTION
Without this, users are greeted with https://github.com/numtide/nixpkgs-unfree/blob/main/default.nix

When they use `nixpkgs-unfree` like this: https://gitlab.com/dar/home-nix/-/blob/main/flake.nix#L9-10