### PR TITLE
fix: Only update .gitignore when a link is indeed created

### DIFF
--- a/lib/hooks/link.nix
+++ b/lib/hooks/link.nix
@@ -29,24 +29,25 @@ in
 
     # Run extra shell hook
     extra_hook
+
+    # Add this output to gitignore if not already
+    if ! test -f .gitignore
+    then
+      touch .gitignore
+    fi
+    if ! grep -qF "/${output}" .gitignore
+    then
+      if ! grep -qF "${gitignore-sentinel}" .gitignore
+      then
+        echo -e "\n# nixago: ${gitignore-sentinel}" >> .gitignore
+      fi
+      newgitignore="$(awk '1;/${gitignore-sentinel}/{ print "/${output}"; }' .gitignore)"
+      echo -e -n "$newgitignore" > .gitignore
+      git add .gitignore
+      log "${ansi.bold}${ansi."11"}'/${output}' added to .gitignore${ansi.reset}"
+    fi
   else
     # this was an existing file
     error "refusing to overwrite '${output}'"
-  fi
-  # Add this output to gitignore if not already
-  if ! test -f .gitignore
-  then
-    touch .gitignore
-  fi
-  if ! grep -qF "/${output}" .gitignore
-  then
-    if ! grep -qF "${gitignore-sentinel}" .gitignore
-    then
-      echo -e "\n# nixago: ${gitignore-sentinel}" >> .gitignore
-    fi
-    newgitignore="$(awk '1;/${gitignore-sentinel}/{ print "/${output}"; }' .gitignore)"
-    echo -e -n "$newgitignore" > .gitignore
-    git add .gitignore
-    log "${ansi.bold}${ansi."11"}'/${output}' added to .gitignore${ansi.reset}"
   fi
 ''


### PR DESCRIPTION
It does not make sense to update `.gitignore` if there is an existing manually created file 