### PR TITLE
Unconditionally evaluate `hook.extra` as a function

### DIFF
--- a/lib/make.nix
+++ b/lib/make.nix
@@ -37,10 +37,7 @@ in
         hook =
           userRequest.hook
           // {
-            extra =
-              if builtins.isFunction userRequest.hook.extra
-              then userRequest.hook.extra userRequest.data
-              else userRequest.hook.extra;
+            extra = (pkgs.lib.toFunction userRequest.hook.extra) userRequest.data;
           };
       };
 


### PR DESCRIPTION
In nixos/nixpkgs#386208, function arguments are preserved in some circumstances. This caused issues such as divnix/std#399. Ultimately, it comes down to the `builtins.isFunction` check, which does not detect functors.

With this patch, `hook.extra` is coerced to a function unconditionally. If it is a constant, any arguments are ignored, so behaviour does not change.